### PR TITLE
Updated PhD information and order

### DIFF
--- a/modules/wowchemy/layouts/partials/widgets/people.html
+++ b/modules/wowchemy/layouts/partials/widgets/people.html
@@ -67,8 +67,8 @@
 
   {{/* All other full-time */}}
   
-    {{ $middleStart := 1 }}                               
-    {{ $middleEnd := sub $authorsCount 6 }}
+    {{ $middleStart := 1 }}
+    {{ $middleEnd := sub $authorsCount 4 }}
     {{ if gt $middleEnd $middleStart }}               
     {{ $middleAuthors := first $middleEnd (after $middleStart $query) }}
   <div class="row row-middle" style="margin-top: 15px;">
@@ -107,7 +107,7 @@
   {{/* Alumni */}}
   <div class="row row-last" style="margin-top: 15px;justify-content: center;width: -webkit-fill-available;">
     {{ if eq . "Alumni" }}
-      {{ range last 4 $query }}
+      {{ range last 5 $query }}
     {{ $avatar := (.Resources.ByType "image").GetMatch "*avatar*" }}
   {{/* Get link to user's profile page. */}}
   {{ $link := "" }}
@@ -138,7 +138,7 @@
   {{ end }}
   {{ else }}
   {{/* Master thesis, Hiwi */}}
-    {{ range last 5 $query }}
+    {{ range last 3 $query }}
     {{ $avatar := (.Resources.ByType "image").GetMatch "*avatar*" }}
   {{/* Get link to user's profile page. */}}
   {{ $link := "" }}

--- a/starters/academic/content/authors/abhishek/_index.md
+++ b/starters/academic/content/authors/abhishek/_index.md
@@ -6,7 +6,7 @@ title: Abhishek Samanta
 first_name: Abhishek
 last_name: Samanta
 
-weight: 15
+weight: 13
 
 # Username (this should match the folder name)
 authors:
@@ -37,7 +37,7 @@ education:
       institution: Saarland University - Max Planck Informatics
     - course: Bachelor of Technology, Computer Science
       institution: KIIT
-      
+  
 
 social:
   - icon: envelope
@@ -69,7 +69,6 @@ email: ''
 user_groups:
   - Research team members
 ---
-
 I am an AI researcher at the Department of Neuroradiology, Universitätsklinikum Bonn, Germany, where I work on building foundational models, and pipelines for better assistance to doctors and diagnosis. My interests lie in understanding the capabilities and limitations of architectures, and making them more generalizable. Apart from research, I was briefly associated with pharmaceutical consulting and building smart models for deepfake detection.
 
 Outside of academia, I am a part-time band manager, a chess player and involved in German politics and policymaking.

--- a/starters/academic/content/authors/german/_index.md
+++ b/starters/academic/content/authors/german/_index.md
@@ -6,7 +6,7 @@ title: German Mikhelson
 first_name: German
 last_name: Mikhelson
 
-weight: 17
+weight: 16
 # Username (this should match the folder name)
 authors:
   - german
@@ -35,8 +35,17 @@ education:
     - course: "MSc Informatics"
       institution: "Rhenish Friedrich Wilhelm University of Bonn"
       year: "Since 2023"
+    - course: "BSc Computer Science"
+      institution: "Lomonosov Moscow State University, Faculty of Computational Mathematics and Cybernetics"
+      year: "Since 2019"
 
 social:
+  - icon: google-scholar
+    icon_pack: ai
+    link: https://scholar.google.com/citations?user=JRU7gp4AAAAJ&hl=ru
+  - icon: linkedin
+    icon_pack: fab
+    link: https://www.linkedin.com/in/german-mikhelson-404aa42aa/
   - icon: github
     icon_pack: fab
     link: https://github.com/Wektor607
@@ -54,4 +63,3 @@ email: 'mikhelson.g@gmail.com'
 user_groups:
   - Research team members
 ---
-

--- a/starters/academic/content/authors/pavithra/_index.md
+++ b/starters/academic/content/authors/pavithra/_index.md
@@ -6,7 +6,7 @@ title: Pavithra Raghavan
 first_name: Pavithra
 last_name: Raghavan
 
-weight: 16
+weight: 25
 # Username (this should match the folder name)
 authors:
   - pavithra
@@ -52,5 +52,5 @@ email: 'pavithra.r.31001@gmail.com'
 
 # Organizational groups that you belong to (for People widget)
 user_groups:
-  - Research team members
+  - Alumni
 ---

--- a/starters/academic/content/authors/ritwik/_index.md
+++ b/starters/academic/content/authors/ritwik/_index.md
@@ -38,7 +38,7 @@ education:
   courses:
     - course: Bachelors in Computer Engineering 
       institution: University of Pune
-    
+  
 social:
   - icon: envelope
     icon_pack: fas
@@ -65,5 +65,3 @@ email: 'ritwik.ghosh@ukbonn.de'
 user_groups:
   - Research team members
 ---
-
-

--- a/starters/academic/content/authors/samuel/_index.md
+++ b/starters/academic/content/authors/samuel/_index.md
@@ -6,7 +6,7 @@ title: Samuel Kwong
 first_name: Samuel
 last_name: Kwong
 
-weight: 13
+weight: 15
 # Username (this should match the folder name)
 authors:
   - samuel
@@ -63,4 +63,3 @@ email: 'samuel.kwong@ukbonn.de'
 user_groups:
   - Research team members
 ---
-


### PR DESCRIPTION
## Summary
- Fix people widget template (people.html): Alumni row was hard-capped at 4 entries and the "junior" row at Research team members was positionally sliced rather than role-based, causing profiles to silently drop or be misplaced.
- Move Pavithra to Alumni group (moved to end of Alumni order).
- Reorder German and Abhishek ahead of the Software Engineer entries.
- Update German's education (added BSc) and add Google Scholar / LinkedIn social links.
